### PR TITLE
Expose sigrid REST API endpoints

### DIFF
--- a/API_DOCUMENTATION.md
+++ b/API_DOCUMENTATION.md
@@ -1,0 +1,341 @@
+# Sigrid API Documentation
+
+This document describes the REST API endpoints added to Sigrid for frontend integration.
+
+## Base URL
+
+When running locally: `http://localhost:8091/api/`
+
+## Endpoints
+
+### Room Management
+
+#### GET /api/rooms
+List all active rooms.
+
+**Response:**
+```json
+{
+  "rooms": [
+    {
+      "course": "PGK",
+      "name": "Hacke",
+      "supervisors": [{"name": "alice", "number": 1, "id": "alice-1"}],
+      "students": [{"name": "bob", "number": 1, "id": "bob-1"}],
+      "helpQueue": [
+        {
+          "user": {"name": "bob", "number": 1, "id": "bob-1"},
+          "timestamp": {"year": 2025, "month": 10, "day": 9, "hour": 14, "minute": 30, "second": 0, "display": "2025-10-09 14:30:00"},
+          "minutesWaited": 5
+        }
+      ],
+      "approvalQueue": [],
+      "created": {"year": 2025, "month": 10, "day": 9, "hour": 14, "minute": 0, "second": 0, "display": "2025-10-09 14:00:00"},
+      "isActive": true,
+      "isExpired": false,
+      "maxQueuingTime": 5
+    }
+  ]
+}
+```
+
+#### GET /api/rooms/{course}/{room}
+Get details for a specific room.
+
+**Parameters:**
+- `course` (path): Course code (e.g., "PGK", "DOD")
+- `room` (path): Room name (e.g., "Hacke", "Pluto")
+
+**Response:** Room object (same structure as in rooms array above)
+
+**Error Response (404):**
+```json
+{
+  "error": "RoomNotFound",
+  "message": "Room Hacke in course PGK does not exist"
+}
+```
+
+---
+
+### User Management
+
+#### GET /api/users/{userId}
+Get user status and current room.
+
+**Parameters:**
+- `userId` (path): User ID (format: "name-number", e.g., "alice-1")
+
+**Response:**
+```json
+{
+  "user": {"name": "alice", "number": 1, "id": "alice-1"},
+  "room": {
+    "course": "PGK",
+    "name": "Hacke",
+    ...
+  }
+}
+```
+
+**Note:** `room` will be `null` if user is not in any room.
+
+---
+
+### Student Operations
+
+#### POST /api/student/login
+Log in as a student and join a room.
+
+**Query Parameters:**
+- `name` (required): Student's first name
+- `course` (required): Course code
+- `room` (required): Room name
+
+**Response:**
+```json
+{
+  "user": {"name": "bob", "number": 1, "id": "bob-1"},
+  "room": {
+    "course": "PGK",
+    "name": "Hacke",
+    ...
+  }
+}
+```
+
+**Notes:**
+- If a user with the same name exists, a number suffix is auto-incremented (bob-1, bob-2, etc.)
+- Creates the room if it doesn't exist
+- Automatically purges expired rooms and orphaned users
+
+#### POST /api/student/state
+Update student state (request help, ready for approval, working, or exit).
+
+**Query Parameters:**
+- `userid` (required): User ID (from login response)
+- `course` (required): Course code
+- `room` (required): Room name
+- `state` (required): One of: `work`, `help`, `ready`, `exit`
+
+**Valid States:**
+- `work` - Student is working (removes from queues)
+- `help` - Student needs help (adds to help queue)
+- `ready` - Student is ready for approval (adds to approval queue)
+- `exit` - Student leaves (removes user from system)
+
+**Response:**
+```json
+{
+  "room": { ... },
+  "message": "Status updated"
+}
+```
+
+**Error Response (400):**
+```json
+{
+  "error": "InvalidState",
+  "message": "State 'invalid' is not valid. Valid states: work, help, ready, exit"
+}
+```
+
+---
+
+### Supervisor Operations
+
+#### POST /api/supervisor/login
+Log in as a supervisor and join a room.
+
+**Query Parameters:**
+- `name` (required): Supervisor's first name
+- `course` (required): Course code
+- `room` (required): Room name
+
+**Response:** Same as student login
+
+#### POST /api/supervisor/action
+Perform supervisor actions (pop queues, remove users, merge rooms, etc.).
+
+**Query Parameters:**
+- `userid` (required): Supervisor user ID
+- `course` (required): Course code
+- `room` (required): Room name
+- `action` (required): Action to perform (see below)
+- `targetuser` (optional): Target user ID for `removeuser` action
+- `otherroom` (optional): Other room name for `mergeroom` action
+
+**Valid Actions:**
+- `supervising` - Get current room state
+- `pophelp` - Remove first student from help queue
+- `popready` - Remove first student from approval queue
+- `clearhelp` - Clear entire help queue
+- `clearready` - Clear entire approval queue
+- `removeuser` - Remove a specific user (requires `targetuser` parameter)
+- `mergeroom` - Merge another room into this one (requires `otherroom` parameter)
+- `gone` - Supervisor leaves the room
+- `purge` - Delete the entire room
+
+**Response:**
+```json
+{
+  "room": { ... },
+  "message": "Help queue popped"
+}
+```
+
+**Examples:**
+
+Pop help queue:
+```
+POST /api/supervisor/action?userid=alice-1&course=PGK&room=Hacke&action=pophelp
+```
+
+Remove a user:
+```
+POST /api/supervisor/action?userid=alice-1&course=PGK&room=Hacke&action=removeuser&targetuser=bob-1
+```
+
+Merge rooms:
+```
+POST /api/supervisor/action?userid=alice-1&course=PGK&room=Hacke&action=mergeroom&otherroom=Pluto
+```
+
+**Error Responses:**
+```json
+{
+  "error": "QueueEmpty",
+  "message": "Help queue is empty or room not found"
+}
+```
+
+```json
+{
+  "error": "InvalidOperation",
+  "message": "Cannot remove yourself"
+}
+```
+
+---
+
+## Data Models
+
+### User
+```json
+{
+  "name": "alice",
+  "number": 1,
+  "id": "alice-1"
+}
+```
+
+### Date
+```json
+{
+  "year": 2025,
+  "month": 10,
+  "day": 9,
+  "hour": 14,
+  "minute": 30,
+  "second": 0,
+  "display": "2025-10-09 14:30:00"
+}
+```
+
+### Room
+```json
+{
+  "course": "PGK",
+  "name": "Hacke",
+  "supervisors": [User, ...],
+  "students": [User, ...],
+  "helpQueue": [QueueItem, ...],
+  "approvalQueue": [QueueItem, ...],
+  "created": Date,
+  "isActive": true,
+  "isExpired": false,
+  "maxQueuingTime": 5
+}
+```
+
+### QueueItem
+```json
+{
+  "user": User,
+  "timestamp": Date,
+  "minutesWaited": 5
+}
+```
+
+---
+
+## Error Handling
+
+All errors return HTTP status 400 (Bad Request) with a JSON body:
+
+```json
+{
+  "error": "ErrorCode",
+  "message": "Human-readable error message"
+}
+```
+
+**Common Error Codes:**
+- `RoomNotFound` - The specified room doesn't exist
+- `UserNotFound` - The specified user doesn't exist
+- `InvalidState` - Invalid state parameter
+- `InvalidAction` - Invalid supervisor action
+- `LoginFailed` - Could not complete login
+- `UpdateFailed` - Could not update state
+- `QueueEmpty` - Attempted to pop from empty queue
+- `InvalidOperation` - Operation not allowed (e.g., removing yourself)
+- `InvalidUserId` - Malformed user ID
+- `MergeFailed` - Could not merge rooms
+
+---
+
+## Implementation Notes
+
+### Backward Compatibility
+All existing HTML endpoints remain functional:
+- `/sigrid/*` - Student interface
+- `/beppe/*` - Supervisor interface
+- `/sigrid/monitor` - Monitor dashboard
+
+The HTML and API endpoints share the same underlying database, so they can be used interchangeably.
+
+### Input Validation
+All input parameters are validated and sanitized:
+- Names: Letters only, max 25 characters
+- Course codes: Alphanumeric, max 25 characters (with mapping: EDAA45→PGK, EDAA60/EITA65→DOD)
+- Room names: Alphanumeric, max 20 characters, capitalized
+- User IDs: Format "name-number" (e.g., "alice-1")
+
+### Room Lifecycle
+- Rooms are automatically created when first user joins
+- Rooms are marked removable when empty or after 10 hours
+- Expired/empty rooms are purged on login requests
+
+### Thread Safety
+All operations use atomic updates via `AtomicKeyValueStore`, ensuring thread-safe concurrent access.
+
+---
+
+## Example Frontend Flow
+
+### Student Workflow
+1. **Login:** `POST /api/student/login?name=bob&course=PGK&room=Hacke`
+   - Save `user.id` from response
+2. **Request help:** `POST /api/student/state?userid=bob-1&course=PGK&room=Hacke&state=help`
+3. **Back to work:** `POST /api/student/state?userid=bob-1&course=PGK&room=Hacke&state=work`
+4. **Exit:** `POST /api/student/state?userid=bob-1&course=PGK&room=Hacke&state=exit`
+
+### Supervisor Workflow
+1. **Login:** `POST /api/supervisor/login?name=alice&course=PGK&room=Hacke`
+   - Save `user.id` from response
+2. **Monitor room:** `GET /api/rooms/PGK/Hacke` (poll periodically)
+3. **Help student:** `POST /api/supervisor/action?userid=alice-1&course=PGK&room=Hacke&action=pophelp`
+4. **Exit:** `POST /api/supervisor/action?userid=alice-1&course=PGK&room=Hacke&action=gone`
+
+### Monitor Dashboard
+1. **List all rooms:** `GET /api/rooms` (poll every 10 seconds)

--- a/build.sbt
+++ b/build.sbt
@@ -4,6 +4,7 @@ ThisBuild / scalaVersion := "2.13.16"
 
 libraryDependencies += "com.typesafe.akka" %% "akka-http"   % "10.2.10"
 libraryDependencies += "com.typesafe.akka" %% "akka-stream" % "2.6.20"
+libraryDependencies += "com.typesafe.akka" %% "akka-http-spray-json" % "10.2.10"
 
 scalacOptions ++= Seq("-unchecked", "-deprecation")
 

--- a/src/main/scala/ApiActions.scala
+++ b/src/main/scala/ApiActions.scala
@@ -1,0 +1,393 @@
+import akka.http.scaladsl.server.StandardRoute
+import akka.http.scaladsl.server.Directives._
+import akka.http.scaladsl.model._
+import spray.json._
+import JsonFormats._
+
+/** API actions that return JSON responses instead of HTML. Reuses the same
+  * business logic from db operations.
+  */
+trait ApiActions {
+  self: WebServer =>
+
+  def log(msg: String): Unit = println(s"\nAPI @ ${Date.now().show}> $msg")
+
+  private def replyJson[T: JsonWriter](
+      data: T,
+      status: StatusCode = StatusCodes.OK
+  ): StandardRoute = {
+    val json = data.toJson.prettyPrint
+    val entity: HttpEntity.Strict =
+      HttpEntity(ContentTypes.`application/json`, json)
+    complete(status, entity)
+  }
+
+  private def errorResponse(error: String, message: String): StandardRoute = {
+    log(s"ERROR: $error - $message")
+    replyJson(ErrorResponse(error, message), StatusCodes.BadRequest)
+  }
+
+  // GET /api/rooms - List all active rooms
+  def apiListRooms(): StandardRoute = {
+    log("request: GET /api/rooms")
+    val nPurgedRooms = db.purgeRemovableRooms()
+    if (nPurgedRooms > 0) log(s"purged $nPurgedRooms removable rooms")
+
+    val rooms = db.rooms
+    replyJson(RoomListResponse(rooms))
+  }
+
+  // GET /api/rooms/{course}/{room} - Get specific room details
+  def apiGetRoom(course: String, roomName: String): StandardRoute = {
+    log(s"request: GET /api/rooms/$course/$roomName")
+    val rk = RoomKey(course, roomName)
+    db.roomsToMap.get(rk) match {
+      case Some(room) => replyJson(room)
+      case None =>
+        errorResponse(
+          "RoomNotFound",
+          s"Room $roomName in course $course does not exist"
+        )
+    }
+  }
+
+  // GET /api/users/{userId} - Get user status and current room
+  def apiGetUser(userId: String): StandardRoute = {
+    log(s"request: GET /api/users/$userId")
+    User.fromUserId(userId) match {
+      case Some(user) if db.hasUser(user) =>
+        val roomOpt = db.findUserInSomeRoom(user)
+        replyJson(UserStatusResponse(user, roomOpt))
+      case _ =>
+        errorResponse("UserNotFound", s"User $userId does not exist")
+    }
+  }
+
+  // POST /api/student/login - Student login
+  def apiStudentLogin(
+      name: String,
+      course: String,
+      room: String
+  ): StandardRoute = {
+    log(
+      s"request: POST /api/student/login?name=$name&course=$course&room=$room"
+    )
+
+    val nPurgedRooms = db.purgeRemovableRooms()
+    if (nPurgedRooms > 0) log(s"purged $nPurgedRooms removable rooms")
+
+    val nPurgedUsers = db.purgeRemovableUsers()
+    if (nPurgedUsers > 0) log(s"purged $nPurgedUsers removable users")
+
+    val u = db.addUser(name)
+    log(s"added $u to userNamesToMap=${db.userNamesToMap}")
+
+    val rOpt = db.addRoomIfNotExists(course, room)
+    log(s"room before update: $rOpt")
+
+    val rOpt2 = db.addStudentIfRoomExists(u, course, room)
+    log(s"room after updated: $rOpt2")
+
+    rOpt2 match {
+      case Some(r) => replyJson(LoginResponse(u, r))
+      case None =>
+        db.removeUser(u)
+        errorResponse(
+          "LoginFailed",
+          s"Could not add student to room $room in course $course"
+        )
+    }
+  }
+
+  // POST /api/supervisor/login - Supervisor login
+  def apiSupervisorLogin(
+      name: String,
+      course: String,
+      room: String
+  ): StandardRoute = {
+    log(
+      s"request: POST /api/supervisor/login?name=$name&course=$course&room=$room"
+    )
+
+    val nPurgedRooms = db.purgeRemovableRooms()
+    if (nPurgedRooms > 0) log(s"purged $nPurgedRooms removable rooms")
+
+    val nPurgedUsers = db.purgeRemovableUsers()
+    if (nPurgedUsers > 0) log(s"purged $nPurgedUsers removable users")
+
+    val u = db.addUser(name)
+    log(s"added $u to userNamesToMap=${db.userNamesToMap}")
+
+    val rOpt = db.addRoomIfNotExists(course, room)
+    log(s"room before update: $rOpt")
+
+    val rOpt2 = db.addSupervisorIfRoomExists(u, course, room)
+
+    val sup: Set[User] = rOpt2.map(_.supervisors).getOrElse(Set())
+    if (sup.contains(u)) {
+      log(s"supervisor $u added to room: $rOpt2")
+      replyJson(LoginResponse(u, rOpt2.get))
+    } else {
+      log(s"ERROR: could not add $u to $rOpt2")
+      db.removeUser(u)
+      errorResponse(
+        "LoginFailed",
+        s"Could not add supervisor to room $room in course $course"
+      )
+    }
+  }
+
+  // POST /api/student/state - Update student state
+  def apiStudentUpdateState(
+      userId: String,
+      course: String,
+      roomCheck: String,
+      state: String
+  ): StandardRoute = {
+    log(
+      s"request: POST /api/student/state?userid=$userId&course=$course&room=$roomCheck&state=$state"
+    )
+
+    val uOpt = User.fromUserId(userId)
+    var movedToRoomMsg = ""
+
+    // Check if room exists, or find user's actual room (in case of room merge)
+    val r: String = if (!db.hasRoom(course, roomCheck) && uOpt.isDefined) {
+      val rOpt: Option[Room] = db.findUserInSomeRoom(uOpt.get)
+      if (rOpt.isDefined) {
+        val rn = rOpt.get.name
+        if (rn != roomCheck) movedToRoomMsg = s"Moved to room $rn"
+        log(s"User $userId is in a non-existing room, moved to $rn")
+        rn
+      } else roomCheck
+    } else roomCheck
+
+    // Validate
+    if (!db.hasRoom(course, r)) {
+      return errorResponse(
+        "RoomNotFound",
+        s"Room $r in course $course does not exist"
+      )
+    }
+    if (uOpt.isEmpty || !db.hasUser(uOpt.get)) {
+      return errorResponse("UserNotFound", s"User $userId does not exist")
+    }
+    if (!ui.validStudentState.contains(state)) {
+      return errorResponse(
+        "InvalidState",
+        s"State '$state' is not valid. Valid states: ${ui.validStudentState.mkString(", ")}"
+      )
+    }
+
+    val user = uOpt.get
+
+    state match {
+      case "exit" =>
+        log(s"exit student $userId")
+        val okOpt = uOpt.map(db.removeUser)
+        if (!okOpt.getOrElse(false)) log(s"ERROR: removeUser $userId $uOpt")
+        replyJson(
+          StateUpdateResponse(
+            Room(course, r), // Empty room representation
+            s"Student $userId logged out"
+          )
+        )
+
+      case "help" =>
+        val rOpt = db.wantHelp(user, course, r)
+        log(s"help $userId updated room to $rOpt")
+        rOpt match {
+          case Some(room) =>
+            replyJson(StateUpdateResponse(room, movedToRoomMsg))
+          case None =>
+            errorResponse("UpdateFailed", "Could not update to help state")
+        }
+
+      case "ready" =>
+        val rOpt = db.wantApproval(user, course, r)
+        log(s"ready $userId updated room to $rOpt")
+        rOpt match {
+          case Some(room) =>
+            replyJson(StateUpdateResponse(room, movedToRoomMsg))
+          case None =>
+            errorResponse("UpdateFailed", "Could not update to ready state")
+        }
+
+      case "work" =>
+        val rOpt = db.working(user, course, r)
+        log(s"work $userId updated room to $rOpt")
+        rOpt match {
+          case Some(room) =>
+            replyJson(StateUpdateResponse(room, movedToRoomMsg))
+          case None =>
+            errorResponse("UpdateFailed", "Could not update to work state")
+        }
+
+      case _ =>
+        errorResponse("InvalidState", s"Unknown state: $state")
+    }
+  }
+
+  // POST /api/supervisor/action - Perform supervisor actions
+  def apiSupervisorAction(
+      userId: String,
+      course: String,
+      room: String,
+      action: String,
+      targetUserId: String = "",
+      otherRoom: String = ""
+  ): StandardRoute = {
+    log(
+      s"request: POST /api/supervisor/action?userid=$userId&course=$course&room=$room&action=$action"
+    )
+
+    // Validate
+    if (!db.hasRoom(course, room)) {
+      return errorResponse(
+        "RoomNotFound",
+        s"Room $room in course $course does not exist"
+      )
+    }
+    val uOpt = User.fromUserId(userId)
+    if (uOpt.isEmpty || !db.hasUser(uOpt.get)) {
+      return errorResponse("UserNotFound", s"User $userId does not exist")
+    }
+    if (!ui.validSupervisorState.contains(action) && action != "supervising") {
+      return errorResponse("InvalidAction", s"Action '$action' is not valid")
+    }
+
+    val user = uOpt.get
+
+    action match {
+      case "supervising" =>
+        log(s"supervising $userId")
+        db.roomsToMap.get(RoomKey(course, room)) match {
+          case Some(r) => replyJson(StateUpdateResponse(r, ""))
+          case None    => errorResponse("RoomNotFound", s"Room not found")
+        }
+
+      case "pophelp" =>
+        log(s"pophelp chosen by supervisor $userId")
+        db.popHelpQueue(course, room) match {
+          case Some(r) =>
+            log(s"popped help queue in room $course/$room")
+            replyJson(StateUpdateResponse(r, "Help queue popped"))
+          case None =>
+            errorResponse("QueueEmpty", "Help queue is empty or room not found")
+        }
+
+      case "popready" =>
+        log(s"popready chosen by supervisor $userId")
+        db.popApprovalQueue(course, room) match {
+          case Some(r) =>
+            log(s"popped approval queue in room $course/$room")
+            replyJson(StateUpdateResponse(r, "Approval queue popped"))
+          case None =>
+            errorResponse(
+              "QueueEmpty",
+              "Approval queue is empty or room not found"
+            )
+        }
+
+      case "clearhelp" =>
+        log(s"clearhelp chosen by supervisor $userId")
+        db.clearHelpQueue(course, room) match {
+          case Some(r) =>
+            log(s"cleared help queue in room $course/$room")
+            replyJson(StateUpdateResponse(r, "Help queue cleared"))
+          case None =>
+            errorResponse("UpdateFailed", "Could not clear help queue")
+        }
+
+      case "clearready" =>
+        log(s"clearready chosen by supervisor $userId")
+        db.clearApprovalQueue(course, room) match {
+          case Some(r) =>
+            log(s"cleared approval queue in room $course/$room")
+            replyJson(StateUpdateResponse(r, "Approval queue cleared"))
+          case None =>
+            errorResponse("UpdateFailed", "Could not clear approval queue")
+        }
+
+      case "removeuser" =>
+        log(
+          s"action removeuser: supervisor=$userId; try remove name=$targetUserId"
+        )
+        if (userId == targetUserId) {
+          return errorResponse("InvalidOperation", "Cannot remove yourself")
+        }
+        User.fromUserId(targetUserId) match {
+          case Some(targetUser) =>
+            if (db.removeUser(targetUser)) {
+              log(s"removed user $targetUserId requested by $userId")
+              db.roomsToMap.get(RoomKey(course, room)) match {
+                case Some(r) =>
+                  replyJson(
+                    StateUpdateResponse(r, s"User $targetUserId removed")
+                  )
+                case None =>
+                  replyJson(
+                    StateUpdateResponse(
+                      Room(course, room),
+                      s"User $targetUserId removed"
+                    )
+                  )
+              }
+            } else {
+              errorResponse("UserNotFound", s"User $targetUserId not found")
+            }
+          case None =>
+            errorResponse("InvalidUserId", s"Invalid user ID: $targetUserId")
+        }
+
+      case "mergeroom" =>
+        log(
+          s"action mergeroom: supervisor=$userId; try merge room other=$otherRoom into this room=$room"
+        )
+        if (!db.hasRoom(course, otherRoom)) {
+          return errorResponse(
+            "RoomNotFound",
+            s"Room $otherRoom does not exist in course $course"
+          )
+        }
+        if (otherRoom == room) {
+          return errorResponse(
+            "InvalidOperation",
+            "Cannot merge room with itself"
+          )
+        }
+        db.mergeRooms(course, otherRoom, room) match {
+          case Some(r) =>
+            log(s"merged room $otherRoom into $room")
+            replyJson(
+              StateUpdateResponse(r, s"Room $otherRoom merged into this room")
+            )
+          case None => errorResponse("MergeFailed", "Could not merge rooms")
+        }
+
+      case "gone" =>
+        log(s"gone supervisor $userId")
+        db.goodbye(user, course, room)
+        db.removeUserIfNotInAnyRoom(user)
+        replyJson(
+          StateUpdateResponse(
+            Room(course, room),
+            s"Supervisor $userId logged out"
+          )
+        )
+
+      case "purge" =>
+        log(s"purge supervisor $userId room $course $room")
+        db.removeRoom(course, room) match {
+          case Some(r) =>
+            db.removeUserIfNotInAnyRoom(user)
+            log(s"removed room $course/$room")
+            replyJson(StateUpdateResponse(r, s"Room deleted"))
+          case None => errorResponse("RoomNotFound", "Room not found")
+        }
+
+      case _ =>
+        errorResponse("UnknownAction", s"Unknown action: $action")
+    }
+  }
+}

--- a/src/main/scala/JsonFormats.scala
+++ b/src/main/scala/JsonFormats.scala
@@ -1,0 +1,128 @@
+import spray.json._
+
+/** JSON serialization formats for API responses */
+object JsonFormats extends DefaultJsonProtocol {
+
+  // Basic formats for User
+  implicit object UserFormat extends RootJsonFormat[User] {
+    def write(u: User) = JsObject(
+      "name" -> JsString(u.name),
+      "number" -> JsNumber(u.number),
+      "id" -> JsString(u.id)
+    )
+
+    def read(value: JsValue) =
+      value.asJsObject.getFields("name", "number") match {
+        case Seq(JsString(name), JsNumber(number)) => User(name, number.toInt)
+        case _ => throw DeserializationException("User expected")
+      }
+  }
+
+  // Format for Date
+  implicit object DateFormat extends RootJsonFormat[Date] {
+    def write(d: Date) = JsObject(
+      "year" -> JsNumber(d.year),
+      "month" -> JsNumber(d.month),
+      "day" -> JsNumber(d.dayOfMonth),
+      "hour" -> JsNumber(d.hour),
+      "minute" -> JsNumber(d.minute),
+      "second" -> JsNumber(d.second),
+      "display" -> JsString(d.show)
+    )
+
+    def read(value: JsValue) = {
+      val fields = value.asJsObject.fields
+      Date(
+        year = fields("year").convertTo[Int],
+        month = fields("month").convertTo[Int],
+        dayOfMonth = fields("day").convertTo[Int],
+        hour = fields("hour").convertTo[Int],
+        minute = fields("minute").convertTo[Int],
+        second = fields("second").convertTo[Int]
+      )
+    }
+  }
+
+  // Format for RoomKey
+  implicit object RoomKeyFormat extends RootJsonFormat[RoomKey] {
+    def write(rk: RoomKey) = JsObject(
+      "course" -> JsString(rk.course),
+      "roomName" -> JsString(rk.roomName)
+    )
+
+    def read(value: JsValue) =
+      value.asJsObject.getFields("course", "roomName") match {
+        case Seq(JsString(course), JsString(roomName)) =>
+          RoomKey(course, roomName)
+        case _ => throw DeserializationException("RoomKey expected")
+      }
+  }
+
+  // Format for queue items (User, Date) tuples
+  implicit object QueueItemFormat extends RootJsonFormat[(User, Date)] {
+    def write(item: (User, Date)) = JsObject(
+      "user" -> item._1.toJson,
+      "timestamp" -> item._2.toJson,
+      "minutesWaited" -> JsNumber(Room.timeWaited(item).toMinutes)
+    )
+
+    def read(value: JsValue) =
+      value.asJsObject.getFields("user", "timestamp") match {
+        case Seq(user, timestamp) =>
+          (user.convertTo[User], timestamp.convertTo[Date])
+        case _ => throw DeserializationException("QueueItem expected")
+      }
+  }
+
+  // Format for Room
+  implicit object RoomFormat extends RootJsonFormat[Room] {
+    def write(r: Room) = JsObject(
+      "course" -> JsString(r.course),
+      "name" -> JsString(r.name),
+      "supervisors" -> JsArray(r.supervisors.map(_.toJson).toVector),
+      "students" -> JsArray(r.students.map(_.toJson).toVector),
+      "helpQueue" -> JsArray(r.helpQueue.map(_.toJson)),
+      "approvalQueue" -> JsArray(r.approvalQueue.map(_.toJson)),
+      "created" -> r.created.toJson,
+      "isActive" -> JsBoolean(r.isActive),
+      "isExpired" -> JsBoolean(r.isExpired),
+      "maxQueuingTime" -> JsNumber(r.maxQueuingTime())
+    )
+
+    def read(value: JsValue) = {
+      val fields = value.asJsObject.fields
+      Room(
+        course = fields("course").convertTo[String],
+        name = fields("name").convertTo[String],
+        supervisors = fields("supervisors").convertTo[Vector[User]].toSet,
+        students = fields("students").convertTo[Vector[User]].toSet,
+        helpQueue = fields("helpQueue").convertTo[Vector[(User, Date)]],
+        approvalQueue = fields("approvalQueue").convertTo[Vector[(User, Date)]],
+        created = fields("created").convertTo[Date]
+      )
+    }
+  }
+
+  // API response formats
+  case class ErrorResponse(error: String, message: String)
+  implicit val errorResponseFormat: RootJsonFormat[ErrorResponse] = jsonFormat2(
+    ErrorResponse
+  )
+
+  case class LoginResponse(user: User, room: Room)
+  implicit val loginResponseFormat: RootJsonFormat[LoginResponse] = jsonFormat2(
+    LoginResponse
+  )
+
+  case class StateUpdateResponse(room: Room, message: String)
+  implicit val stateUpdateResponseFormat: RootJsonFormat[StateUpdateResponse] =
+    jsonFormat2(StateUpdateResponse)
+
+  case class RoomListResponse(rooms: Vector[Room])
+  implicit val roomListResponseFormat: RootJsonFormat[RoomListResponse] =
+    jsonFormat1(RoomListResponse)
+
+  case class UserStatusResponse(user: User, room: Option[Room])
+  implicit val userStatusResponseFormat: RootJsonFormat[UserStatusResponse] =
+    jsonFormat2(UserStatusResponse)
+}

--- a/src/main/scala/SigridServer.scala
+++ b/src/main/scala/SigridServer.scala
@@ -2,49 +2,124 @@ import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.StandardRoute
 
 /** Sigrid web server url routing, delegating to SigridActions. */
-object SigridServer extends WebServer with SigridActions {
+object SigridServer extends WebServer with SigridActions with ApiActions {
+
+  // Override the conflicting log method to use a unified implementation
+  override def log(msg: String): Unit = println(
+    s"\nSIGRID @ ${Date.now().show}> $msg"
+  )
 
   // helper methods to make input string formats valid up-front:
-  private def vn(name: String): String   = User.validName(name) 
+  private def vn(name: String): String = User.validName(name)
   private def vc(course: String): String = RoomKey.validCourse(course)
-  private def vr(room: String): String   = RoomKey.validRoomName(room)
-  private def vs(state: String): String  = state.filter(_.isLetter).toLowerCase
-  private def vu(uid: String): String    = User.validUserId(uid)
+  private def vr(room: String): String = RoomKey.validRoomName(room)
+  private def vs(state: String): String = state.filter(_.isLetter).toLowerCase
+  private def vu(uid: String): String = User.validUserId(uid)
 
-  /* Routing of incoming web server requests, delegating to SigridActions. */
+  /* Routing of incoming web server requests, delegating to SigridActions and ApiActions. */
   override def routes =
-    path("hello") { get { log(s"request: /hello"); reply(ui.helloPage) } }  ~
-    path("beppe") { get {
-      log(s"request: /beppe")
-      db.purgeRemovableRooms()
-      reply(ui.supervisorStartPage()) 
-    } } ~
-    path("beppe" / "login") { get { 
-      parameters("name", "course", "room", "state") { (n, c, r, s) =>
-        supervisorLogin(vn(n), vc(c), vr(r), vs(s))
-    } } } ~
-    path("beppe" / "update") { get { 
-      parameters("userid", "course", "room", "state", "name", "other") { (u, c, r, s, n, o) =>
-        println(s"*** DEBUG: parameters($u, $c, $r, $s, $n, $o)")
-        supervisorUpdate(vu(u), vc(c), vr(r), vs(s), vu(n), vr(o))
-    } } } ~
-    path("sigrid") { get {
-        log(s"request: /sigrid")
-        db.purgeRemovableRooms()
-        reply(ui.studentStartPage()) 
-    } } ~
-    path("sigrid" / "monitor") { get {
-      print(".")
-      db.purgeRemovableRooms()
-      reply(ui.monitorPage()) 
-    } } ~
-    path("sigrid" / "login") { get { 
-      parameters("name", "course", "room", "state") { (n, c, r, s) =>
-        studentLogin(vn(n), vc(c), vr(r), vs(s))
-    } } } ~
-    path("sigrid" / "update") { get { 
-      parameters("userid", "course", "room", "state") { (u, c, r, s) =>
-        studentUpdate(vu(u), vc(c), vr(r), vs(s))
-    } } }
+    path("hello") { get { log(s"request: /hello"); reply(ui.helloPage) } } ~
+      // API routes (JSON responses)
+      path("api" / "rooms") { get { apiListRooms() } } ~
+      path("api" / "rooms" / Segment / Segment) { (course, room) =>
+        get { apiGetRoom(vc(course), vr(room)) }
+      } ~
+      path("api" / "users" / Segment) { userId =>
+        get { apiGetUser(vu(userId)) }
+      } ~
+      path("api" / "student" / "login") {
+        post {
+          parameters("name", "course", "room") { (n, c, r) =>
+            apiStudentLogin(vn(n), vc(c), vr(r))
+          }
+        }
+      } ~
+      path("api" / "student" / "state") {
+        post {
+          parameters("userid", "course", "room", "state") { (u, c, r, s) =>
+            apiStudentUpdateState(vu(u), vc(c), vr(r), vs(s))
+          }
+        }
+      } ~
+      path("api" / "supervisor" / "login") {
+        post {
+          parameters("name", "course", "room") { (n, c, r) =>
+            apiSupervisorLogin(vn(n), vc(c), vr(r))
+          }
+        }
+      } ~
+      path("api" / "supervisor" / "action") {
+        post {
+          parameters(
+            "userid",
+            "course",
+            "room",
+            "action",
+            "targetuser".optional,
+            "otherroom".optional
+          ) { (u, c, r, a, t, o) =>
+            apiSupervisorAction(
+              vu(u),
+              vc(c),
+              vr(r),
+              vs(a),
+              vu(t.getOrElse("")),
+              vr(o.getOrElse(""))
+            )
+          }
+        }
+      } ~
+      // HTML routes (existing endpoints for backward compatibility)
+      path("beppe") {
+        get {
+          log(s"request: /beppe")
+          db.purgeRemovableRooms()
+          reply(ui.supervisorStartPage())
+        }
+      } ~
+      path("beppe" / "login") {
+        get {
+          parameters("name", "course", "room", "state") { (n, c, r, s) =>
+            supervisorLogin(vn(n), vc(c), vr(r), vs(s))
+          }
+        }
+      } ~
+      path("beppe" / "update") {
+        get {
+          parameters("userid", "course", "room", "state", "name", "other") {
+            (u, c, r, s, n, o) =>
+              println(s"*** DEBUG: parameters($u, $c, $r, $s, $n, $o)")
+              supervisorUpdate(vu(u), vc(c), vr(r), vs(s), vu(n), vr(o))
+          }
+        }
+      } ~
+      path("sigrid") {
+        get {
+          log(s"request: /sigrid")
+          db.purgeRemovableRooms()
+          reply(ui.studentStartPage())
+        }
+      } ~
+      path("sigrid" / "monitor") {
+        get {
+          print(".")
+          db.purgeRemovableRooms()
+          reply(ui.monitorPage())
+        }
+      } ~
+      path("sigrid" / "login") {
+        get {
+          parameters("name", "course", "room", "state") { (n, c, r, s) =>
+            studentLogin(vn(n), vc(c), vr(r), vs(s))
+          }
+        }
+      } ~
+      path("sigrid" / "update") {
+        get {
+          parameters("userid", "course", "room", "state") { (u, c, r, s) =>
+            studentUpdate(vu(u), vc(c), vr(r), vs(s))
+          }
+        }
+      }
 
 }


### PR DESCRIPTION
This PR adds data-only HTTP endpoints to the Sigrid server. It is fully backwards compatible, meaning the current endpoints that return full HTML pages are unaffected. The idea behind this is to allow for custom frontends to utalize the same single source of truth if people (like I) want to create own UI's for Sigrid.

The api endpoints can be accessed through the `/api/` path. Some examples are...

`GET /api/rooms/{course}/{room}`, which gets the details for a specific room
`POST /api/supervisor/login`, which can be used to create a new room and log in to that room as a supervisor

All the existing functionality has essentially been mirrored, and the complete API documentations can be found in `API_DOCUMENTATION.md`. 
